### PR TITLE
Only change sensitivity for mouse input

### DIFF
--- a/DInputWrapper/HOOKDirectInput.cpp
+++ b/DInputWrapper/HOOKDirectInput.cpp
@@ -28,7 +28,7 @@ HRESULT	WINAPI HOOKDirectInput::ConfigureDevices(LPDICONFIGUREDEVICESCALLBACK lp
 HRESULT	WINAPI HOOKDirectInput::CreateDevice(REFGUID rguid, LPDIRECTINPUTDEVICE8 *lpDirectInputDevice, LPUNKNOWN pUnkOuter)
 {
 	HRESULT res = actual->CreateDevice(rguid, lpDirectInputDevice, pUnkOuter);
-	if (FAILED(res))
+	if (rguid != GUID_SysMouse || FAILED(res))
 		return res;
 
 	IDirectInputDevice8 *dev = new HOOKDirectInputDevice(*lpDirectInputDevice);


### PR DESCRIPTION
As it was coded, all devices would have the data for their inputs matching offset DIMOFS_Y multiplied by aspect. For certain lower sensitivities this happens to not cause problems. But in my case, using an ultrawide display, it caused my '3' key on the keyboard to no longer work in game.